### PR TITLE
Fix json-ld broken link

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Calavera helps to create a full-Javascript webapp from [Markdown](http://daringfireball.net/projects/markdown/) files.
 
-Basically, it converts Markdown files stored in a [Git](https://git-scm.com/) repository to [JSON-LD](json-ld.org) files
+Basically, it converts Markdown files stored in a [Git](https://git-scm.com/) repository to [JSON-LD](http://json-ld.org/) files
 using the [Schema.org](https://schema.org/) vocabulary.
 Those files include metadata extracted from the Git repository (author name, last modification date...).
 


### PR DESCRIPTION
I just saw a broken link on the README.md for json-ld.org.
Currently the link points to https://github.com/dunglas/calavera/blob/master/json-ld.org which is a 404.
I changed it to point to http://json-ld.org/.
